### PR TITLE
Allow a generic factory to be used along side the named one

### DIFF
--- a/src/Doctrine/ORM/Decorator/EntityFactoryManagerDecorator.php
+++ b/src/Doctrine/ORM/Decorator/EntityFactoryManagerDecorator.php
@@ -3,6 +3,7 @@ namespace Dittto\DoctrineEntityFactories\Doctrine\ORM\Decorator;
 
 use Dittto\DoctrineEntityFactories\Doctrine\ORM\Mapping\EntityFactoryAware;
 use Dittto\DoctrineEntityFactories\Doctrine\ORM\Mapping\EntityFactoryInterface;
+use Dittto\DoctrineEntityFactories\Doctrine\ORM\Mapping\GenericFactoryInterface;
 use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -18,6 +19,14 @@ class EntityFactoryManagerDecorator extends EntityManagerDecorator implements En
         $metadataFactory = $this->wrapped->getMetadataFactory();
         if ($metadataFactory instanceof EntityFactoryAware) {
             $metadataFactory->addEntityFactory($name, $entityFactory);
+        }
+    }
+
+    public function addGenericFactory(GenericFactoryInterface $genericFactory): void
+    {
+        $metadataFactory = $this->wrapped->getMetadataFactory();
+        if ($metadataFactory instanceof EntityFactoryAware) {
+            $metadataFactory->addGenericFactory($genericFactory);
         }
     }
 }

--- a/src/Doctrine/ORM/Mapping/ClassMetadataFactoryWithEntityFactories.php
+++ b/src/Doctrine/ORM/Mapping/ClassMetadataFactoryWithEntityFactories.php
@@ -11,11 +11,13 @@ class ClassMetadataFactoryWithEntityFactories extends ClassMetadataFactory imple
 {
     /** @var EntityFactoryInterface[] */
     public static $entityFactories = [];
+    /** @var GenericFactoryInterface|null */
+    public static $genericFactory;
 
     /** @var EntityManagerInterface */
     private $em;
 
-    public function setEntityManager(EntityManagerInterface $em): void
+    public function setEntityManager(EntityManagerInterface $em)
     {
         parent::setEntityManager($em);
         $this->em = $em;
@@ -35,6 +37,11 @@ class ClassMetadataFactoryWithEntityFactories extends ClassMetadataFactory imple
         self::$entityFactories[$name] = $entityFactory;
     }
 
+    public function addGenericFactory(GenericFactoryInterface $genericFactory): void
+    {
+        self::$genericFactory = $genericFactory;
+    }
+
     /**
      * @return EntityFactoryInterface[]
      */
@@ -43,12 +50,11 @@ class ClassMetadataFactoryWithEntityFactories extends ClassMetadataFactory imple
         return self::$entityFactories;
     }
 
-
-    protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService): void
+    public function wakeupReflection(ClassMetadata $class, ReflectionService $reflService)
     {
         parent::wakeupReflection($class, $reflService);
         if ($class instanceof ClassMetadataWithEntityFactories) {
-            $class->setFactories(self::$entityFactories);
+            $class->setFactories(self::$entityFactories, self::$genericFactory);
         }
     }
 }

--- a/src/Doctrine/ORM/Mapping/ClassMetadataWithEntityFactories.php
+++ b/src/Doctrine/ORM/Mapping/ClassMetadataWithEntityFactories.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Dittto\DoctrineEntityFactories\Doctrine\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -6,13 +7,20 @@ use Doctrine\ORM\Mapping\NamingStrategy;
 
 class ClassMetadataWithEntityFactories extends ClassMetadata
 {
-    /** @var EntityFactoryInterface[]  */
+    /** @var EntityFactoryInterface[] */
     private $entityFactories;
+    /** @var GenericFactoryInterface|null */
+    private $genericFactory;
 
-    public function __construct($entityName, NamingStrategy $namingStrategy = null, array $entityFactories = [])
-    {
+    public function __construct(
+        $entityName,
+        NamingStrategy $namingStrategy = null,
+        array $entityFactories = [],
+        GenericFactoryInterface $genericFactory = null
+    ) {
         parent::__construct($entityName, $namingStrategy);
         $this->entityFactories = $entityFactories;
+        $this->genericFactory  = $genericFactory;
     }
 
     public function newInstance()
@@ -21,11 +29,16 @@ class ClassMetadataWithEntityFactories extends ClassMetadata
             return $this->entityFactories[$this->name]->getEntity();
         }
 
+        if ($this->genericFactory !== null) {
+            return $this->genericFactory->getEntity($this->name);
+        }
+
         return parent::newInstance();
     }
 
-    public function setFactories(array $entityFactories): void
+    public function setFactories(array $entityFactories, GenericFactoryInterface $genericFactory = null)
     {
         $this->entityFactories = $entityFactories;
+        $this->genericFactory  = $genericFactory;
     }
 }

--- a/src/Doctrine/ORM/Mapping/EntityFactoryAware.php
+++ b/src/Doctrine/ORM/Mapping/EntityFactoryAware.php
@@ -4,4 +4,6 @@ namespace Dittto\DoctrineEntityFactories\Doctrine\ORM\Mapping;
 interface EntityFactoryAware
 {
     public function addEntityFactory(string $name, EntityFactoryInterface $entityFactory): void;
+
+    public function addGenericFactory(GenericFactoryInterface $genericFactory): void;
 }

--- a/src/Doctrine/ORM/Mapping/GenericFactoryInterface.php
+++ b/src/Doctrine/ORM/Mapping/GenericFactoryInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace Dittto\DoctrineEntityFactories\Doctrine\ORM\Mapping;
+
+interface GenericFactoryInterface
+{
+    public function getEntity(string $className);
+}


### PR DESCRIPTION
My entities use a generic factory, this allows that to be used as well
as the individual named factories